### PR TITLE
Fix production warning bash bug

### DIFF
--- a/Source/Configuration/parse-microservice-config.sh
+++ b/Source/Configuration/parse-microservice-config.sh
@@ -18,5 +18,6 @@ shopt -s nocasematch
 export DOLITTLE_IS_PRODUCTION="TRUE"
 if ! [[ "$DOLITTLE_ENVIRONMENT" =~ "^prod" ]]; then
     export -n DOLITTLE_IS_PRODUCTION
+    unset DOLITTLE_IS_PRODUCTION
 fi
 shopt -u nocasematch


### PR DESCRIPTION
## Summary

Fixes a bug where the `DOLITTLE_IS_PRODUCTION` environment variable was not properly unset in non-production environments.

### Fixed

- The production warning was printed in non-production environments because the environment variable was not properly unset.
